### PR TITLE
feat(dashboard): EEG–EMG quality, comparator, and hardware (research loop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ L’application est organisée en deux sections (**EMG — Hand movement** et **
 
 **EMG — Hand movement** : choisir un dataset dans `data/preprocessed/`, charger un modèle depuis `src/models/`, puis lancer l’inférence ; pages outils : **Dataset Quality Checker**, **Model Comparator**, **Hardware Impact Tracker**.
 
-**EEG–EMG** : placer des `.npz` (EEG + EMG) dans `data/eeg_emg/` et des checkpoints PyTorch (`.pth`) dans `src/eeg_emg/` (ou utiliser les téléversements dans la barre latérale), puis lancer l’inférence sur une fraction de validation. Voir `docs/dashboard_emg_eeg_emg_roadmap.md` pour la suite (qualité des jeux, comparateur, profilage matériel).
+**EEG–EMG** : placer des `.npz` (EEG + EMG) dans `data/eeg_emg/` et des checkpoints PyTorch (`.pth`) dans `src/eeg_emg/` (ou téléversements). Pages : **Decoder**, **Dataset quality**, **Model comparator**, **Hardware impact** (rapports JSON sous `data/eeg_emg_*_reports/`). Détails : `docs/dashboard_emg_eeg_emg_roadmap.md`.
 
 ---
 

--- a/docs/dashboard_emg_eeg_emg_roadmap.md
+++ b/docs/dashboard_emg_eeg_emg_roadmap.md
@@ -12,7 +12,7 @@ This document tracks the split of the Streamlit app into two product areas and p
 | [73](https://github.com/Umbra-EIP/umbra-mirror/issues/73) | EEG–EMG model comparator (PyTorch regression) |
 | [74](https://github.com/Umbra-EIP/umbra-mirror/issues/74) | EEG–EMG hardware impact tracker (PyTorch) |
 
-## Current layout (after #70 / #71)
+## Current layout
 
 - Entry: `streamlit run src/dashboard/app.py`
 - **EMG — Hand movement**
@@ -20,29 +20,21 @@ This document tracks the split of the Streamlit app into two product areas and p
   - Dataset quality (`emg/dataset_quality.py`)
   - Model comparator (`emg/model_comparator_page.py`)
   - Hardware impact (`emg/hardware_impact_page.py`)
-- **EEG–EMG**
-  - Decoder (`eeg_emg/eeg2emg_dashboard.py`): paired `.npz`, PyTorch `.pth` from `eeg2emg_run.py`
-  - Inference helpers: `src/eeg_emg/eeg2emg_inference.py`
-  - Paths: `EEG_EMG_DATA_DIR`, `EEG_EMG_MODEL_DIR` in `src/config.py`
+- **EEG–EMG** (research loop on collected `.npz` + `.pth`)
+  - Decoder (`eeg_emg/eeg2emg_dashboard.py`)
+  - Dataset quality (`eeg_emg/dataset_quality_page.py`) — `src/dashboard/eeg_emg_dataset_quality.py`, reports `EEG_EMG_QUALITY_REPORTS_DIR`
+  - Model comparator (`eeg_emg/model_comparator_page.py`) — `src/dashboard/eeg_emg_model_compare.py`, `EEG_EMG_COMPARISON_REPORTS_DIR`
+  - Hardware impact (`eeg_emg/hardware_impact_page.py`) — `src/dashboard/eeg_emg_torch_hardware.py`, `EEG_EMG_HARDWARE_REPORTS_DIR`
+  - Inference / windowing: `src/eeg_emg/eeg2emg_inference.py`; NPZ keys: `load_npz_with_keys()` in `eeg2emg_run.py`
+  - Paths: `EEG_EMG_DATA_DIR`, `EEG_EMG_MODEL_DIR` + report dirs in `src/config.py`
 
-## Remaining steps (by issue)
+Issues [#72](https://github.com/Umbra-EIP/umbra-mirror/issues/72)–[#74](https://github.com/Umbra-EIP/umbra-mirror/issues/74) are covered by this stack.
 
-### #72 — Dataset quality (EEG–EMG)
+## Follow-up ideas
 
-1. Define quality rules for paired EEG/EMG arrays (shape alignment, NaNs, channel counts, duration).
-2. Add `src/dashboard/eeg_emg/dataset_quality_page.py` (or similar) and optional report directory (e.g. `data/eeg_emg_quality_reports/`).
-3. Reuse UX patterns from `src/dashboard/dataset_quality.py` where sensible.
-
-### #73 — Model comparator (EEG–EMG)
-
-1. List/compare `.pth` checkpoints (metadata from saved `config`, file mtime, size).
-2. Run a fixed validation protocol (same `run_inference` or shared evaluator) and persist JSON reports.
-3. Optional: overlay prediction curves for two models.
-
-### #74 — Hardware impact (EEG–EMG)
-
-1. Port `hardware_profiler` patterns: Torch model load time, RAM, GPU memory (if CUDA), batch latency.
-2. New page under EEG–EMG section; save reports under e.g. `data/eeg_emg_hardware_reports/` (add to `src/config.py` when introduced).
+- Quality page: per-channel histograms or PSD preview.
+- Comparator: overlay predicted vs true EMG for two checkpoints on the same window.
+- Hardware: optional CUDA peak memory during a longer stress loop.
 
 ## Verification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ ignore = [
 "src/dashboard/hardware_profiler.py" = ["E402"]
 "src/dashboard/emg/*.py" = ["E402"]
 "src/dashboard/eeg_emg/*.py" = ["E402"]
+"src/dashboard/eeg_emg_dataset_quality.py" = ["E402"]
+"src/dashboard/eeg_emg_model_compare.py" = ["E402"]
+"src/dashboard/eeg_emg_torch_hardware.py" = ["E402"]
 # Scripts that manipulate sys.path to import src.* from the repo root
 "scripts/run_comparison.py" = ["E402"]
 

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,9 @@ MODEL_DIR = "src/models"
 # EEG→EMG dashboard & data (paired .npz, PyTorch checkpoints)
 EEG_EMG_DATA_DIR = "data/eeg_emg"
 EEG_EMG_MODEL_DIR = "src/eeg_emg"
+EEG_EMG_QUALITY_REPORTS_DIR = "data/eeg_emg_quality_reports"
+EEG_EMG_COMPARISON_REPORTS_DIR = "data/eeg_emg_comparison_reports"
+EEG_EMG_HARDWARE_REPORTS_DIR = "data/eeg_emg_hardware_reports"
 
 QUALITY_REPORTS_DIR = "data/quality_reports"
 COMPARISON_REPORTS_DIR = "data/comparison_reports"

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -35,6 +35,21 @@ pages = {
             title="Decoder",
             icon="🧠",
         ),
+        st.Page(
+            str(_dashboard / "eeg_emg" / "dataset_quality_page.py"),
+            title="Dataset quality",
+            icon="📋",
+        ),
+        st.Page(
+            str(_dashboard / "eeg_emg" / "model_comparator_page.py"),
+            title="Model comparator",
+            icon="🔬",
+        ),
+        st.Page(
+            str(_dashboard / "eeg_emg" / "hardware_impact_page.py"),
+            title="Hardware impact",
+            icon="⚡",
+        ),
     ],
 }
 

--- a/src/dashboard/eeg_emg/dataset_quality_page.py
+++ b/src/dashboard/eeg_emg/dataset_quality_page.py
@@ -1,0 +1,116 @@
+# EEG–EMG dataset quality — Streamlit page
+
+import os
+import sys
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[3]
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import pandas as pd
+import streamlit as st
+
+from src.config import EEG_EMG_DATA_DIR
+from src.dashboard.eeg_emg_dataset_quality import (
+    check_eeg_emg_npz,
+    list_npz_files,
+    list_saved_reports,
+    load_report,
+    save_report,
+)
+
+st.set_page_config(
+    page_title="EEG–EMG Dataset Quality | Umbra",
+    page_icon="📋",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.title("📋 EEG–EMG Dataset Quality")
+st.caption(
+    "Validate paired `.npz` archives (EEG + EMG keys, shapes, NaNs, sliding-window count) before "
+    "training or benchmarking."
+)
+
+st.sidebar.header("Dataset (.npz)")
+if not os.path.isdir(EEG_EMG_DATA_DIR):
+    os.makedirs(EEG_EMG_DATA_DIR, exist_ok=True)
+npz_files = list_npz_files()
+uploaded = st.sidebar.file_uploader("Or upload .npz", type=["npz"], accept_multiple_files=False)
+
+selected_path: str | None = None
+if uploaded is not None:
+    dest_dir = Path(EEG_EMG_DATA_DIR) / "_uploads"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / uploaded.name
+    dest.write_bytes(uploaded.getvalue())
+    selected_path = str(dest)
+elif npz_files:
+    choice = st.sidebar.selectbox("File", npz_files)
+    selected_path = os.path.join(EEG_EMG_DATA_DIR, choice)
+
+window_size = st.sidebar.number_input("Window size (for window count)", 32, 4096, 256, 32)
+step = st.sidebar.number_input("Step", 1, 2048, 128, 1)
+report_name = st.sidebar.text_input("Report name", value="default").strip() or "default"
+
+if st.sidebar.button("Run quality check", type="primary") and selected_path:
+    with st.spinner("Checking…"):
+        rep = check_eeg_emg_npz(
+            selected_path, window_size=int(window_size), step=int(step), report_name=report_name
+        )
+    st.session_state["eeg_emg_q_report"] = rep
+    try:
+        p = save_report(rep)
+        st.sidebar.success(f"Saved `{p.name}`")
+    except Exception as exc:
+        st.sidebar.warning(f"Save failed: {exc}")
+
+st.sidebar.divider()
+st.sidebar.subheader("Saved reports")
+saved = list_saved_reports()
+if saved:
+    chosen_path = st.sidebar.selectbox("Load report", options=saved, format_func=lambda p: p.name)
+    if st.sidebar.button("Load"):
+        loaded = load_report(chosen_path)
+        if loaded:
+            st.session_state["eeg_emg_q_report"] = loaded
+        else:
+            st.sidebar.error("Failed to load.")
+
+if not npz_files and uploaded is None:
+    st.info(f"Add `.npz` files under `{EEG_EMG_DATA_DIR}/` or upload one.")
+    st.stop()
+
+rep = st.session_state.get("eeg_emg_q_report")
+if rep is None:
+    st.info("Run a quality check from the sidebar.")
+    st.stop()
+
+verdict = "PASS" if rep.passed else "FAIL"
+st.markdown(f"### Verdict: **{verdict}**")
+if rep.error:
+    st.error(rep.error)
+
+cols = st.columns(4)
+cols[0].metric("EEG trials shape", str(rep.eeg_trials_shape or "—"))
+cols[1].metric("EMG trials shape", str(rep.emg_trials_shape or "—"))
+cols[2].metric("Sliding windows", rep.n_windows)
+cols[3].metric("Min time (samples)", rep.min_time_samples)
+
+detail = {
+    "eeg_key": rep.eeg_key,
+    "emg_key": rep.emg_key,
+    "pre_windowed": rep.pre_windowed,
+    "time_aligned": rep.time_aligned,
+    "eeg_nan/inf": f"{rep.eeg_nan} / {rep.eeg_inf}",
+    "emg_nan/inf": f"{rep.emg_nan} / {rep.emg_inf}",
+    "flat EEG channels (trial 0)": rep.flat_eeg_channels,
+    "flat EMG channels (trial 0)": rep.flat_emg_channels,
+}
+st.dataframe(pd.DataFrame([detail]), use_container_width=True)
+
+if rep.warnings:
+    st.subheader("Warnings")
+    for w in rep.warnings:
+        st.warning(w)

--- a/src/dashboard/eeg_emg/hardware_impact_page.py
+++ b/src/dashboard/eeg_emg/hardware_impact_page.py
@@ -1,0 +1,132 @@
+# EEG–EMG hardware impact — Streamlit page
+
+import os
+import sys
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[3]
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import pandas as pd
+import streamlit as st
+
+from src.config import EEG_EMG_DATA_DIR, EEG_EMG_MODEL_DIR
+from src.dashboard.eeg_emg_dataset_quality import list_npz_files
+from src.dashboard.eeg_emg_torch_hardware import (
+    get_torch_system_info,
+    list_saved_torch_hardware_reports,
+    load_torch_hardware_payload,
+    run_torch_profile,
+    save_torch_hardware_report,
+)
+
+st.set_page_config(
+    page_title="EEG–EMG Hardware Impact | Umbra",
+    page_icon="⚡",
+    layout="wide",
+)
+
+st.title("⚡ EEG–EMG Hardware Impact (PyTorch)")
+st.caption("Measure checkpoint load time and forward-pass latency on your validation windows.")
+
+st.sidebar.header("Data (.npz)")
+npz_files = list_npz_files()
+uploaded = st.sidebar.file_uploader("Or upload .npz", type=["npz"])
+selected_npz: str | None = None
+if uploaded is not None:
+    dest = Path(EEG_EMG_DATA_DIR) / "_uploads" / uploaded.name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(uploaded.getvalue())
+    selected_npz = str(dest)
+elif npz_files:
+    selected_npz = os.path.join(EEG_EMG_DATA_DIR, st.sidebar.selectbox("Dataset", npz_files))
+
+st.sidebar.header("Checkpoint")
+if not os.path.isdir(EEG_EMG_MODEL_DIR):
+    st.sidebar.error("Model directory missing.")
+    pth_files: list[str] = []
+else:
+    pth_files = sorted(
+        f for f in os.listdir(EEG_EMG_MODEL_DIR) if f.endswith(".pth") and not f.startswith(".")
+    )
+
+model_file: str | None = None
+if pth_files:
+    model_file = st.sidebar.selectbox("Model", pth_files)
+
+st.sidebar.header("Profiling")
+bs_str = st.sidebar.text_input("Batch sizes (comma-separated)", value="1, 4, 8, 16")
+n_runs = st.sidebar.number_input("Batches per size", 1, 100, 5)
+step = st.sidebar.number_input("Window step", 1, 2048, 128)
+val_ratio = st.sidebar.slider("Validation fraction", 0.05, 0.5, 0.2, 0.05)
+no_cuda = st.sidebar.checkbox("Force CPU", value=False)
+run_label = st.sidebar.text_input("Report label", value="profile")
+
+sys_info = get_torch_system_info()
+st.sidebar.caption(
+    f"Torch {sys_info.torch_version} · "
+    f"{'CUDA ' + str(sys_info.cuda_version) if sys_info.cuda_available else 'CPU only'}"
+)
+
+if st.sidebar.button("Run profile", type="primary") and selected_npz and model_file:
+    try:
+        batch_sizes = [int(x.strip()) for x in bs_str.split(",") if x.strip()]
+    except ValueError:
+        batch_sizes = [1, 4, 8, 16]
+    with st.spinner("Profiling…"):
+        report = run_torch_profile(
+            selected_npz,
+            model_file,
+            batch_sizes=batch_sizes,
+            n_batch_runs=int(n_runs),
+            step=int(step),
+            val_ratio=float(val_ratio),
+            no_cuda=no_cuda,
+        )
+    st.session_state["eeg_emg_hw"] = report
+    try:
+        p = save_torch_hardware_report(report, name=run_label)
+        st.sidebar.success(f"Saved `{p.name}`")
+    except Exception as exc:
+        st.sidebar.warning(f"Save failed: {exc}")
+
+st.sidebar.divider()
+saved_hw = list_saved_torch_hardware_reports()
+if saved_hw:
+    lab = [f"{n} — {t}" for n, t, _ in saved_hw]
+    ix = st.sidebar.selectbox("Saved reports", range(len(lab)), format_func=lambda i: lab[i])
+    if st.sidebar.button("Load saved"):
+        path = saved_hw[ix][2]
+        payload = load_torch_hardware_payload(path)
+        if payload:
+            st.session_state["eeg_emg_hw"] = payload.get("report")
+
+rep = st.session_state.get("eeg_emg_hw")
+if rep is None:
+    st.info("Select data + checkpoint and run profiling.")
+    st.stop()
+
+if isinstance(rep, dict):
+    loading = rep.get("loading", {})
+    inference = rep.get("inference", [])
+else:
+    loading = rep.loading
+    inference = rep.inference
+
+st.metric("Load time (s)", f"{loading.get('load_time_s', 0):.3f}")
+if loading.get("load_error"):
+    st.error(loading["load_error"])
+else:
+    c1, c2, c3 = st.columns(3)
+    c1.metric("RAM after load (MB)", f"{loading.get('ram_after_mb', 0):.1f}")
+    cm = loading.get("cuda_mem_after_mb")
+    if cm is not None:
+        c2.metric("CUDA alloc (MB)", f"{cm:.1f}")
+    c3.metric("File (MB)", f"{loading.get('file_size_mb', 0):.2f}")
+
+if inference:
+    st.subheader("Inference latency")
+    st.dataframe(pd.DataFrame(inference), use_container_width=True)
+else:
+    st.warning("No inference timings (empty val set or error).")

--- a/src/dashboard/eeg_emg/model_comparator_page.py
+++ b/src/dashboard/eeg_emg/model_comparator_page.py
@@ -1,0 +1,120 @@
+# EEG–EMG model comparator — Streamlit page
+
+import os
+import sys
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[3]
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import pandas as pd
+import streamlit as st
+
+from src.config import EEG_EMG_DATA_DIR, EEG_EMG_MODEL_DIR
+from src.dashboard.eeg_emg_dataset_quality import list_npz_files
+from src.dashboard.eeg_emg_model_compare import (
+    comparison_result_from_saved_payload,
+    list_saved_comparisons,
+    load_comparison,
+    run_eeg_emg_comparison,
+    save_comparison,
+)
+
+st.set_page_config(
+    page_title="EEG–EMG Model Comparator | Umbra",
+    page_icon="🔬",
+    layout="wide",
+)
+
+st.title("🔬 EEG–EMG Model Comparator")
+st.caption(
+    "Run the same validation protocol on several `.pth` checkpoints (MSE / R² on the val split)."
+)
+
+st.sidebar.header("Data (.npz)")
+npz_files = list_npz_files()
+uploaded = st.sidebar.file_uploader("Or upload .npz", type=["npz"])
+selected_npz: str | None = None
+if uploaded is not None:
+    dest = Path(EEG_EMG_DATA_DIR) / "_uploads" / uploaded.name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(uploaded.getvalue())
+    selected_npz = str(dest)
+elif npz_files:
+    selected_npz = os.path.join(EEG_EMG_DATA_DIR, st.sidebar.selectbox("Dataset", npz_files))
+
+st.sidebar.header("Checkpoints")
+pth_files: list[str] = []
+if not os.path.isdir(EEG_EMG_MODEL_DIR):
+    st.sidebar.error("Model directory missing.")
+else:
+    pth_files = sorted(
+        f for f in os.listdir(EEG_EMG_MODEL_DIR) if f.endswith(".pth") and not f.startswith(".")
+    )
+
+st.sidebar.header("Protocol")
+step = st.sidebar.number_input("Window step", 1, 2048, 128)
+val_ratio = st.sidebar.slider("Validation fraction", 0.05, 0.5, 0.2, 0.05)
+normalize = st.sidebar.checkbox("Z-score normalize", value=True)
+no_cuda = st.sidebar.checkbox("Force CPU", value=False)
+seed = st.sidebar.number_input("RNG seed", 0, 2**31 - 1, 42)
+
+run_name = st.sidebar.text_input("Run label (for save)", value="compare")
+
+models = st.sidebar.multiselect(
+    "Models to compare",
+    options=pth_files,
+    default=pth_files[: min(3, len(pth_files))],
+)
+
+if st.sidebar.button("Run comparison", type="primary") and selected_npz and models:
+    with st.spinner("Evaluating checkpoints…"):
+        result = run_eeg_emg_comparison(
+            selected_npz,
+            models,
+            step=int(step),
+            val_ratio=float(val_ratio),
+            normalize=normalize,
+            seed=int(seed),
+            no_cuda=no_cuda,
+        )
+    st.session_state["eeg_emg_cmp"] = result
+    try:
+        p = save_comparison(result, name=run_name)
+        st.sidebar.success(f"Saved `{p.name}`")
+    except Exception as exc:
+        st.sidebar.warning(f"Save failed: {exc}")
+
+st.sidebar.divider()
+st.sidebar.subheader("Saved runs")
+saved = list_saved_comparisons()
+if saved:
+    labels = [f"{n} — {t}" for n, t, _ in saved]
+    idx = st.sidebar.selectbox("Load", range(len(labels)), format_func=lambda i: labels[i])
+    if st.sidebar.button("Load saved"):
+        path = saved[idx][2]
+        data = load_comparison(path)
+        if data:
+            st.session_state["eeg_emg_cmp"] = comparison_result_from_saved_payload(data)
+
+if not pth_files:
+    st.warning(f"No `.pth` files in `{EEG_EMG_MODEL_DIR}/`.")
+
+raw = st.session_state.get("eeg_emg_cmp")
+if raw is None:
+    st.info("Select a dataset and models, then run comparison.")
+    st.stop()
+
+rows = []
+for row in raw.rows:
+    rows.append(
+        {
+            "model": row.model_file,
+            "MSE": row.mse if not row.error else None,
+            "R²": row.r2 if not row.error else None,
+            "best_val_mse (ckpt)": row.best_val_mse_in_checkpoint,
+            "error": row.error,
+        }
+    )
+st.dataframe(pd.DataFrame(rows), use_container_width=True)

--- a/src/dashboard/eeg_emg_dataset_quality.py
+++ b/src/dashboard/eeg_emg_dataset_quality.py
@@ -1,0 +1,265 @@
+"""Quality checks for paired EEG/EMG `.npz` files used in EEG→EMG research."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from src.config import EEG_EMG_DATA_DIR, EEG_EMG_QUALITY_REPORTS_DIR
+from src.eeg_emg.eeg2emg_inference import prepare_eeg_emg_trials
+from src.eeg_emg.eeg2emg_run import EEGEMGWindowDataset, load_npz_with_keys
+
+# Heuristics for research readiness
+MIN_TIME_SAMPLES = 64
+MIN_TRIALS = 1
+VARIANCE_THRESHOLD_FLAT = 1e-12
+
+
+@dataclass
+class EegEmgQualityReport:
+    """Quality check result for one `.npz` paired recording."""
+
+    file_path: str
+    loaded: bool = False
+    error: Optional[str] = None
+    report_name: str = "default"
+
+    eeg_key: Optional[str] = None
+    emg_key: Optional[str] = None
+    eeg_raw_shape: Optional[tuple] = None
+    emg_raw_shape: Optional[tuple] = None
+    eeg_dtype: Optional[str] = None
+    emg_dtype: Optional[str] = None
+
+    eeg_trials_shape: Optional[tuple] = None
+    emg_trials_shape: Optional[tuple] = None
+    n_trials: int = 0
+    n_eeg_channels: int = 0
+    n_emg_channels: int = 0
+    min_time_samples: int = 0
+    time_aligned: bool = True
+
+    eeg_nan: int = 0
+    eeg_inf: int = 0
+    emg_nan: int = 0
+    emg_inf: int = 0
+
+    eeg_min: Optional[float] = None
+    eeg_max: Optional[float] = None
+    emg_min: Optional[float] = None
+    emg_max: Optional[float] = None
+
+    # Sliding-window feasibility (same defaults as training)
+    window_size: int = 256
+    step: int = 128
+    n_windows: int = 0
+    pre_windowed: bool = False
+
+    flat_eeg_channels: int = 0
+    flat_emg_channels: int = 0
+    warnings: list[str] = field(default_factory=list)
+    passed: bool = False
+
+
+def _safe_filename_stem(path: str) -> str:
+    base = Path(path).stem
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", base).strip("_")
+    return safe or "dataset"
+
+
+def _report_to_dict(r: EegEmgQualityReport) -> dict[str, Any]:
+    d = asdict(r)
+    for k in ("eeg_raw_shape", "emg_raw_shape", "eeg_trials_shape", "emg_trials_shape"):
+        if d.get(k) is not None:
+            d[k] = list(d[k])
+    return d
+
+
+def _report_from_dict(d: dict[str, Any]) -> EegEmgQualityReport:
+    d = dict(d)
+    for k in ("eeg_raw_shape", "emg_raw_shape", "eeg_trials_shape", "emg_trials_shape"):
+        if d.get(k) is not None:
+            d[k] = tuple(d[k])
+    return EegEmgQualityReport(**d)
+
+
+def get_reports_dir() -> Path:
+    path = Path(EEG_EMG_QUALITY_REPORTS_DIR)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def list_saved_reports() -> list[Path]:
+    """Saved quality reports, newest first."""
+    return sorted(
+        get_reports_dir().glob("eeg_emg_q_*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+
+def save_report(report: EegEmgQualityReport) -> Path:
+    """Save report JSON with timestamp prefix for stable listing."""
+    stem = _safe_filename_stem(report.file_path)
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in report.report_name)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = get_reports_dir() / f"eeg_emg_q_{ts}_{stem}_{safe}.json"
+    with open(path, "w") as f:
+        json.dump(_report_to_dict(report), f, indent=2)
+    return path
+
+
+def load_report(path: Path) -> Optional[EegEmgQualityReport]:
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        return _report_from_dict(d)
+    except Exception:
+        return None
+
+
+def list_npz_files() -> list[str]:
+    """Return sorted `.npz` basenames under `EEG_EMG_DATA_DIR`."""
+    if not os.path.isdir(EEG_EMG_DATA_DIR):
+        return []
+    return sorted(
+        f for f in os.listdir(EEG_EMG_DATA_DIR) if f.endswith(".npz") and not f.startswith(".")
+    )
+
+
+def _count_flat_channels(signal_2d: np.ndarray, threshold: float) -> int:
+    """signal_2d: (time, channels). Count channels with near-zero variance."""
+    if signal_2d.ndim != 2:
+        return 0
+    var = np.var(signal_2d, axis=0)
+    return int((var < threshold).sum())
+
+
+def check_eeg_emg_npz(
+    npz_path: str,
+    *,
+    window_size: int = 256,
+    step: int = 128,
+    report_name: str = "default",
+) -> EegEmgQualityReport:
+    """
+    Run integrity and research-readiness checks on a paired EEG/EMG `.npz`.
+
+    Uses the same trial preparation as training/inference (`prepare_eeg_emg_trials`).
+    """
+    report = EegEmgQualityReport(file_path=npz_path, report_name=report_name)
+    report.window_size = window_size
+    report.step = step
+
+    if not os.path.isfile(npz_path):
+        report.error = f"File not found: {npz_path}"
+        return report
+
+    try:
+        eeg_key, emg_key, eeg_raw, emg_raw = load_npz_with_keys(npz_path)
+        report.eeg_key = eeg_key
+        report.emg_key = emg_key
+        eeg_raw = np.asarray(eeg_raw)
+        emg_raw = np.asarray(emg_raw)
+        report.eeg_raw_shape = eeg_raw.shape
+        report.emg_raw_shape = emg_raw.shape
+        report.eeg_dtype = str(eeg_raw.dtype)
+        report.emg_dtype = str(emg_raw.dtype)
+
+        report.eeg_nan = int(np.isnan(eeg_raw).sum())
+        report.eeg_inf = int(np.isinf(eeg_raw).sum())
+        report.emg_nan = int(np.isnan(emg_raw).sum())
+        report.emg_inf = int(np.isinf(emg_raw).sum())
+
+        if report.eeg_nan or report.eeg_inf:
+            report.warnings.append(
+                f"EEG has invalid values: {report.eeg_nan} NaN, {report.eeg_inf} Inf"
+            )
+        if report.emg_nan or report.emg_inf:
+            report.warnings.append(
+                f"EMG has invalid values: {report.emg_nan} NaN, {report.emg_inf} Inf"
+            )
+
+        if np.issubdtype(eeg_raw.dtype, np.number):
+            report.eeg_min = float(np.nanmin(eeg_raw))
+            report.eeg_max = float(np.nanmax(eeg_raw))
+        if np.issubdtype(emg_raw.dtype, np.number):
+            report.emg_min = float(np.nanmin(emg_raw))
+            report.emg_max = float(np.nanmax(emg_raw))
+
+        eeg_trials, emg_trials, pre_w = prepare_eeg_emg_trials(npz_path)
+        report.pre_windowed = pre_w
+        report.eeg_trials_shape = eeg_trials.shape
+        report.emg_trials_shape = emg_trials.shape
+        report.n_trials = int(eeg_trials.shape[0])
+        report.n_eeg_channels = int(eeg_trials.shape[1])
+        report.n_emg_channels = int(emg_trials.shape[1])
+        t_eeg = int(eeg_trials.shape[2])
+        t_emg = int(emg_trials.shape[2])
+        report.min_time_samples = min(t_eeg, t_emg)
+        report.time_aligned = t_eeg == t_emg
+
+        if not report.time_aligned:
+            report.warnings.append(
+                f"Time length mismatch after alignment: EEG={t_eeg}, EMG={t_emg} "
+                "(training may trim shorter; verify source alignment)."
+            )
+
+        dataset = EEGEMGWindowDataset(
+            eeg_trials,
+            emg_trials,
+            window_size=window_size,
+            step=step,
+            normalize=True,
+            pre_windowed=pre_w,
+        )
+        report.n_windows = len(dataset)
+        if report.n_windows == 0:
+            report.warnings.append(
+                f"No sliding windows could be built (window_size={window_size}, step={step})."
+            )
+
+        # Flat-channel sanity on first trial (full time)
+        e0 = eeg_trials[0].T  # (time, ch)
+        m0 = emg_trials[0].T
+        report.flat_eeg_channels = _count_flat_channels(e0, VARIANCE_THRESHOLD_FLAT)
+        report.flat_emg_channels = _count_flat_channels(m0, VARIANCE_THRESHOLD_FLAT)
+        if report.flat_eeg_channels:
+            report.warnings.append(
+                f"EEG has {report.flat_eeg_channels} near-flat channel(s) on trial 0 (var < {VARIANCE_THRESHOLD_FLAT})."
+            )
+        if report.flat_emg_channels:
+            report.warnings.append(
+                f"EMG has {report.flat_emg_channels} near-flat channel(s) on trial 0."
+            )
+
+        report.loaded = True
+
+        critical = (
+            report.eeg_nan > 0
+            or report.eeg_inf > 0
+            or report.emg_nan > 0
+            or report.emg_inf > 0
+            or report.n_windows == 0
+            or report.min_time_samples < MIN_TIME_SAMPLES
+            or report.n_trials < MIN_TRIALS
+        )
+        report.passed = not critical
+        if report.min_time_samples < MIN_TIME_SAMPLES:
+            report.warnings.append(
+                f"Very short recording ({report.min_time_samples} samples); "
+                f"consider at least {MIN_TIME_SAMPLES} for stable windows."
+            )
+
+    except Exception as exc:
+        report.error = str(exc)
+        report.warnings.append(f"Exception during check: {exc}")
+
+    return report

--- a/src/dashboard/eeg_emg_model_compare.py
+++ b/src/dashboard/eeg_emg_model_compare.py
@@ -1,0 +1,192 @@
+"""Compare multiple EEG→EMG PyTorch checkpoints on the same `.npz` (regression metrics)."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+from src.config import EEG_EMG_COMPARISON_REPORTS_DIR, EEG_EMG_MODEL_DIR
+from src.eeg_emg.eeg2emg_inference import run_inference
+
+
+def _torch_load_cpu(path: str) -> dict[str, Any]:
+    try:
+        return torch.load(path, map_location="cpu", weights_only=False)
+    except TypeError:
+        return torch.load(path, map_location="cpu")
+
+
+@dataclass
+class ModelScoreRow:
+    """Per-checkpoint metrics on a fixed protocol."""
+
+    model_file: str
+    mse: float
+    r2: float
+    best_val_mse_in_checkpoint: Optional[float] = None
+    n_eeg_channels: Optional[int] = None
+    n_emg_channels: Optional[int] = None
+    window_size: Optional[int] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class EegEmgComparisonResult:
+    """Aggregated comparison across checkpoints."""
+
+    npz_path: str
+    generated_at: str
+    seed: int
+    step: int
+    val_ratio: float
+    normalize: bool
+    resample_eeg: bool
+    no_cuda: bool
+    rows: list[ModelScoreRow] = field(default_factory=list)
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+def _read_best_val_from_ckpt(path: str) -> Optional[float]:
+    try:
+        ckpt = _torch_load_cpu(path)
+        return float(ckpt["best_val_mse"]) if ckpt.get("best_val_mse") is not None else None
+    except Exception:
+        return None
+
+
+def run_eeg_emg_comparison(
+    npz_path: str,
+    model_files: list[str],
+    *,
+    model_dir: str = EEG_EMG_MODEL_DIR,
+    step: int = 128,
+    val_ratio: float = 0.2,
+    normalize: bool = True,
+    seed: int = 42,
+    resample_eeg: bool = False,
+    eeg_fs: float | None = None,
+    emg_fs: float | None = None,
+    no_cuda: bool = False,
+) -> EegEmgComparisonResult:
+    """
+    Evaluate each checkpoint on ``npz_path`` using the same inference protocol as the decoder.
+
+    ``model_files`` are basename filenames; each is resolved under ``model_dir``.
+    """
+    result = EegEmgComparisonResult(
+        npz_path=npz_path,
+        generated_at=datetime.now().isoformat(timespec="seconds"),
+        seed=seed,
+        step=step,
+        val_ratio=val_ratio,
+        normalize=normalize,
+        resample_eeg=resample_eeg,
+        no_cuda=no_cuda,
+        config={
+            "model_dir": model_dir,
+            "eeg_fs": eeg_fs,
+            "emg_fs": emg_fs,
+        },
+    )
+
+    for name in model_files:
+        path = os.path.join(model_dir, name)
+        row = ModelScoreRow(model_file=name, mse=0.0, r2=0.0)
+        row.best_val_mse_in_checkpoint = _read_best_val_from_ckpt(path)
+        if not os.path.isfile(path):
+            row.error = f"File not found: {path}"
+            result.rows.append(row)
+            continue
+        try:
+            inf = run_inference(
+                npz_path,
+                path,
+                step=step,
+                val_ratio=val_ratio,
+                normalize=normalize,
+                seed=seed,
+                resample_eeg=resample_eeg,
+                eeg_fs=eeg_fs,
+                emg_fs=emg_fs,
+                no_cuda=no_cuda,
+            )
+            row.mse = inf.mse
+            row.r2 = inf.r2
+            ckpt = _torch_load_cpu(path)
+            cfg = ckpt.get("config", {})
+            row.n_eeg_channels = cfg.get("n_eeg_channels")
+            row.n_emg_channels = cfg.get("n_emg_channels")
+            row.window_size = cfg.get("window_size")
+        except Exception as exc:
+            row.error = str(exc)
+        result.rows.append(row)
+
+    return result
+
+
+def get_comparison_reports_dir() -> Path:
+    p = Path(EEG_EMG_COMPARISON_REPORTS_DIR)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def save_comparison(result: EegEmgComparisonResult, name: str = "run") -> Path:
+    """Persist comparison as JSON."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = get_comparison_reports_dir() / f"eeg_emg_cmp_{ts}_{safe}.json"
+    payload = {
+        "name": name,
+        "saved_at": result.generated_at,
+        "result": asdict(result),
+    }
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2, default=str)
+    return path
+
+
+def load_comparison(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def comparison_result_from_saved_payload(payload: dict[str, Any]) -> EegEmgComparisonResult:
+    """Rebuild ``EegEmgComparisonResult`` from JSON saved by ``save_comparison``."""
+    d = payload["result"]
+    return EegEmgComparisonResult(
+        npz_path=d["npz_path"],
+        generated_at=d["generated_at"],
+        seed=d["seed"],
+        step=d["step"],
+        val_ratio=d["val_ratio"],
+        normalize=d["normalize"],
+        resample_eeg=d["resample_eeg"],
+        no_cuda=d["no_cuda"],
+        rows=[ModelScoreRow(**x) for x in d["rows"]],
+        config=d.get("config", {}),
+    )
+
+
+def list_saved_comparisons() -> list[tuple[str, str, Path]]:
+    """Return (name, saved_at, path) newest first."""
+    d = get_comparison_reports_dir()
+    if not d.is_dir():
+        return []
+    out: list[tuple[str, str, Path]] = []
+    for p in sorted(d.glob("eeg_emg_cmp_*.json"), reverse=True):
+        try:
+            with open(p) as f:
+                meta = json.load(f)
+            out.append((meta.get("name", p.stem), meta.get("saved_at", ""), p))
+        except Exception:
+            continue
+    return out

--- a/src/dashboard/eeg_emg_torch_hardware.py
+++ b/src/dashboard/eeg_emg_torch_hardware.py
@@ -1,0 +1,295 @@
+"""Hardware profiling for EEG→EMG PyTorch checkpoints (load + inference latency)."""
+
+from __future__ import annotations
+
+import gc
+import json
+import os
+import platform
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+from src.config import EEG_EMG_HARDWARE_REPORTS_DIR, EEG_EMG_MODEL_DIR
+from src.eeg_emg.eeg2emg_inference import load_eeg2emg_model, prepare_eeg_emg_trials
+from src.eeg_emg.eeg2emg_run import EEGEMGWindowDataset
+
+
+def _process_ram_mb() -> float:
+    try:
+        import psutil
+
+        return psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+    except Exception:
+        return 0.0
+
+
+def _torch_cuda_mem_mb() -> Optional[float]:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return torch.cuda.memory_allocated() / (1024 * 1024)
+    except Exception:
+        return None
+
+
+@dataclass
+class TorchSystemInfo:
+    platform_str: str
+    python_version: str
+    torch_version: str
+    cuda_available: bool
+    cuda_version: Optional[str]
+    device_name: str
+
+
+@dataclass
+class TorchLoadProfile:
+    model_file: str
+    file_size_mb: float
+    load_time_s: float
+    ram_before_mb: float
+    ram_after_mb: float
+    cuda_mem_after_mb: Optional[float]
+    n_eeg_channels: Optional[int] = None
+    n_emg_channels: Optional[int] = None
+    window_size: Optional[int] = None
+    load_error: Optional[str] = None
+
+
+@dataclass
+class TorchInferenceLatency:
+    batch_size: int
+    n_batches: int
+    mean_ms: float
+    std_ms: float
+    p50_ms: float
+    p95_ms: float
+
+
+@dataclass
+class EegEmgTorchHardwareReport:
+    generated_at: str
+    npz_path: str
+    model_file: str
+    system: dict[str, Any]
+    loading: dict[str, Any]
+    inference: list[dict[str, Any]]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+def get_torch_system_info() -> TorchSystemInfo:
+    """Collect Python / PyTorch / CUDA environment."""
+    import torch
+
+    cuda_ver = torch.version.cuda if torch.cuda.is_available() else None
+    dev = "cpu"
+    if torch.cuda.is_available():
+        dev = torch.cuda.get_device_name(0)
+
+    return TorchSystemInfo(
+        platform_str=platform.platform(),
+        python_version=platform.python_version(),
+        torch_version=torch.__version__,
+        cuda_available=torch.cuda.is_available(),
+        cuda_version=cuda_ver,
+        device_name=dev,
+    )
+
+
+def run_torch_profile(
+    npz_path: str,
+    model_file: str,
+    *,
+    model_dir: str = EEG_EMG_MODEL_DIR,
+    batch_sizes: Optional[list[int]] = None,
+    n_batch_runs: int = 5,
+    step: int = 128,
+    val_ratio: float = 0.2,
+    normalize: bool = True,
+    seed: int = 42,
+    no_cuda: bool = False,
+) -> EegEmgTorchHardwareReport:
+    """
+    Load a checkpoint and measure forward-pass latency on the validation subset.
+
+    Uses the same windowing and split as ``run_inference``.
+    """
+    import torch
+    from torch.utils.data import DataLoader, random_split
+
+    if batch_sizes is None:
+        batch_sizes = [1, 4, 8, 16]
+
+    sys_info = get_torch_system_info()
+    path = os.path.join(model_dir, model_file)
+    loading = TorchLoadProfile(
+        model_file=model_file,
+        file_size_mb=os.path.getsize(path) / (1024 * 1024) if os.path.isfile(path) else 0.0,
+        load_time_s=0.0,
+        ram_before_mb=_process_ram_mb(),
+        ram_after_mb=0.0,
+        cuda_mem_after_mb=None,
+    )
+
+    device = torch.device("cpu" if no_cuda else ("cuda" if torch.cuda.is_available() else "cpu"))
+
+    gc.collect()
+    if torch.cuda.is_available() and not no_cuda:
+        torch.cuda.empty_cache()
+
+    t0 = time.perf_counter()
+    cfg: dict[str, Any] = {}
+    try:
+        model, cfg = load_eeg2emg_model(path, map_location=device)
+        loading.n_eeg_channels = cfg.get("n_eeg_channels")
+        loading.n_emg_channels = cfg.get("n_emg_channels")
+        loading.window_size = cfg.get("window_size")
+    except Exception as exc:
+        loading.load_error = str(exc)
+        loading.load_time_s = time.perf_counter() - t0
+        return EegEmgTorchHardwareReport(
+            generated_at=datetime.now().isoformat(timespec="seconds"),
+            npz_path=npz_path,
+            model_file=model_file,
+            system=asdict(sys_info),
+            loading=asdict(loading),
+            inference=[],
+            config={"batch_sizes": batch_sizes, "error": "load_failed"},
+        )
+
+    loading.load_time_s = time.perf_counter() - t0
+    loading.ram_after_mb = _process_ram_mb()
+    loading.cuda_mem_after_mb = _torch_cuda_mem_mb()
+
+    ws = int(cfg.get("window_size", 256))
+    eeg_trials, emg_trials, pre_w = prepare_eeg_emg_trials(npz_path)
+    dataset = EEGEMGWindowDataset(
+        eeg_trials,
+        emg_trials,
+        window_size=ws,
+        step=step,
+        normalize=normalize,
+        pre_windowed=pre_w,
+    )
+
+    n_total = len(dataset)
+    if n_total == 0:
+        return EegEmgTorchHardwareReport(
+            generated_at=datetime.now().isoformat(timespec="seconds"),
+            npz_path=npz_path,
+            model_file=model_file,
+            system=asdict(sys_info),
+            loading=asdict(loading),
+            inference=[],
+            config={"error": "no_windows"},
+        )
+
+    if n_total == 1:
+        val_set = dataset
+    else:
+        n_val = max(1, int(n_total * val_ratio))
+        n_train = n_total - n_val
+        if n_train < 1:
+            n_train, n_val = n_total - 1, 1
+        gen = torch.Generator().manual_seed(seed)
+        _, val_set = random_split(dataset, [n_train, n_val], generator=gen)
+
+    inference_rows: list[dict[str, Any]] = []
+    model.eval()
+
+    for bs in batch_sizes:
+        loader = DataLoader(val_set, batch_size=bs, shuffle=False)
+        times: list[float] = []
+        with torch.no_grad():
+            for i, batch in enumerate(loader):
+                if i >= n_batch_runs:
+                    break
+                xb, _ = batch
+                xb = xb.to(device).float()
+                if xb.size(0) < 1:
+                    continue
+                t1 = time.perf_counter()
+                _ = model(xb)
+                if device.type == "cuda":
+                    torch.cuda.synchronize()
+                times.append((time.perf_counter() - t1) * 1000.0)
+
+        if not times:
+            continue
+        arr = np.array(times)
+        inference_rows.append(
+            asdict(
+                TorchInferenceLatency(
+                    batch_size=bs,
+                    n_batches=len(times),
+                    mean_ms=float(np.mean(arr)),
+                    std_ms=float(np.std(arr)),
+                    p50_ms=float(np.percentile(arr, 50)),
+                    p95_ms=float(np.percentile(arr, 95)),
+                )
+            )
+        )
+
+    return EegEmgTorchHardwareReport(
+        generated_at=datetime.now().isoformat(timespec="seconds"),
+        npz_path=npz_path,
+        model_file=model_file,
+        system=asdict(sys_info),
+        loading=asdict(loading),
+        inference=inference_rows,
+        config={
+            "batch_sizes": batch_sizes,
+            "n_batch_runs": n_batch_runs,
+            "step": step,
+            "val_ratio": val_ratio,
+            "device": str(device),
+        },
+    )
+
+
+def get_hardware_reports_dir() -> Path:
+    p = Path(EEG_EMG_HARDWARE_REPORTS_DIR)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def save_torch_hardware_report(report: EegEmgTorchHardwareReport, name: str = "default") -> Path:
+    """Persist a torch hardware report."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = get_hardware_reports_dir() / f"eeg_emg_hw_{ts}_{safe}.json"
+    payload = {"name": name, "saved_at": report.generated_at, "report": asdict(report)}
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2, default=str)
+    return path
+
+
+def list_saved_torch_hardware_reports() -> list[tuple[str, str, Path]]:
+    d = get_hardware_reports_dir()
+    if not d.is_dir():
+        return []
+    out: list[tuple[str, str, Path]] = []
+    for p in sorted(d.glob("eeg_emg_hw_*.json"), reverse=True):
+        try:
+            with open(p) as f:
+                meta = json.load(f)
+            out.append((meta.get("name", p.stem), meta.get("saved_at", ""), p))
+        except Exception:
+            continue
+    return out
+
+
+def load_torch_hardware_payload(path: Path) -> Optional[dict[str, Any]]:
+    """Load full JSON payload (name, saved_at, report)."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None

--- a/src/eeg_emg/eeg2emg_run.py
+++ b/src/eeg_emg/eeg2emg_run.py
@@ -23,7 +23,15 @@ from torch.utils.data import DataLoader, Dataset
 # -----------------------------
 # Utilities: robust NPZ loading
 # -----------------------------
-def load_npz_anycase(path):
+def load_npz_with_keys(path):
+    """
+    Load a paired EEG/EMG archive and return resolved key names plus arrays.
+
+    Raises
+    ------
+    KeyError
+        If EEG/EMG arrays cannot be resolved from the file.
+    """
     d = np.load(path, allow_pickle=True)
     # map lowercase->original key
     keys = {k.lower(): k for k in d.files}
@@ -69,7 +77,12 @@ def load_npz_anycase(path):
                         break
         else:
             raise KeyError(f"Could not find EEG/EMG in {path}. Keys found: {d.files}")
-    return d[eeg_key], d[emg_key]
+    return eeg_key, emg_key, d[eeg_key], d[emg_key]
+
+
+def load_npz_anycase(path):
+    _, _, eeg, emg = load_npz_with_keys(path)
+    return eeg, emg
 
 
 # -----------------------------

--- a/tests/test_eeg_emg_dataset_quality.py
+++ b/tests/test_eeg_emg_dataset_quality.py
@@ -1,0 +1,24 @@
+"""Tests for EEG–EMG dataset quality checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from src.dashboard.eeg_emg_dataset_quality import check_eeg_emg_npz
+
+
+def test_check_eeg_emg_npz_passes_minimal_pair(tmp_path: Path) -> None:
+    """Sufficient length and no NaNs should yield windows > 0."""
+    t, c_e, c_m = 512, 4, 2
+    eeg = np.random.randn(t, c_e).astype(np.float32)
+    emg = np.random.randn(t, c_m).astype(np.float32)
+    path = tmp_path / "pair.npz"
+    np.savez(path, eeg=eeg, emg=emg)
+
+    rep = check_eeg_emg_npz(str(path), window_size=64, step=32)
+    assert rep.loaded
+    assert rep.n_windows > 0
+    assert rep.eeg_key is not None
+    assert rep.emg_key is not None


### PR DESCRIPTION
## Summary
- **Dataset quality**: `eeg_emg_dataset_quality.py` + `dataset_quality_page.py` — paired `.npz` checks (keys, shapes, NaNs, sliding-window count, flat channels); JSON reports under `EEG_EMG_QUALITY_REPORTS_DIR`.
- **Model comparator**: `eeg_emg_model_compare.py` + page — same `run_inference` protocol on multiple `.pth`; MSE/R² table + checkpoint best val MSE; saved JSON under `EEG_EMG_COMPARISON_REPORTS_DIR`.
- **Hardware**: `eeg_emg_torch_hardware.py` + page — load time, RAM/CUDA alloc, batch latency vs batch size; reports under `EEG_EMG_HARDWARE_REPORTS_DIR`.
- **Shared loader**: `load_npz_with_keys()` in `eeg2emg_run.py`; `load_npz_anycase` delegates to it.

## How to test
- `ruff check .`
- `pytest tests/test_eeg_emg_dataset_quality.py tests/test_eeg2emg_inference.py`
- `streamlit run src/dashboard/app.py` — EEG–EMG section has 4 pages.

Closes #72
Closes #73
Closes #74